### PR TITLE
Fix Custom Block example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ This sample adds a block to the editor based on a `React Element` defined:
 
 ```js
 import MUIRichTextEditor from 'mui-rte'
-import InvertColorsIcon from '@material-ui/icons/TableChartIcon'
+import TableChartIcon from '@material-ui/icons/TableChart'
 
 const MyBlock = (props) => {
     return (

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ This sample adds a control that will trigger a custom callback function:
 
 ```js
 import MUIRichTextEditor from 'mui-rte'
-import InvertColorsIcon from '@material-ui/icons/DoneIcon'
+import DoneIcon from '@material-ui/icons/Done'
 
 <MUIRichTextEditor 
     controls={["my-callback"]}


### PR DESCRIPTION
The Table Chart Icon was imported from incorrect path and the variable name was from the previous custom control example. So the `icon: <TableChartIcon />` property on `customControls` object was referring to an undefined variable.