### PR TITLE
Add 'onFocus' and 'onBlur' properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,8 @@ Object.assign(defaultTheme, {
 |error|`boolean`|optional|Renders the editor with an error style.|
 |onSave|`(data:string) => void`|optional|Function triggered when the save button is pressed. The `data` is a stringified `Draft.Model.Encoding.RawDraftContentState` object.|
 |onChange|`(state: EditorState) => void`|optional|Function triggered on any change in the editor (key input, delete, etc.). The `state` is a `Draft.Model.ImmutableData.EditorState` object.
+|onFocus|`() => void`|optional|Function triggered when when the editor acquires focus.|
+|onBlur|`() => void`|optional|Function triggered when when the editor loses focus.|
 |controls|`string[]`|optional|List of controls to display in the main toolbar. If not provided, all controls will be rendered. Current available values are: "title", "bold", "italic", "underline", "strikethrough", "highlight", "undo", "redo", "link", "media", "numberList", "bulletList", "quote", "code", "clear", "save".|
 |customControls|`TCustomControl[]`|optional|Defines an array of user custom inline styles, blocks and callbacks. See more information in 'Custom Controls' below.|
 |decorators|`TDecorator[]`|optional|Defines an array of user custom decorators. See more information in 'Custom Decorators'.|

--- a/examples/events/index.tsx
+++ b/examples/events/index.tsx
@@ -10,6 +10,10 @@ const focus = () => {
     console.log('Focus on MUIRichTextEditor');
 }
 
+const blur = () => {
+    console.log('Focus lost on MUIRichTextEditor');
+}
+
 const change = (state: EditorState) => {
     // More info about EditorState object at
     // https://draftjs.org/docs/api-reference-editor-state
@@ -33,6 +37,7 @@ const Events = () => {
             onSave={save}
             onChange={change}
             onFocus={focus}
+            onBlur={blur}
         />
     )
 }

--- a/examples/events/index.tsx
+++ b/examples/events/index.tsx
@@ -6,6 +6,10 @@ const save = (data: string) => {
     console.log(data)
 }
 
+const focus = () => {
+    console.log('Focus on MUIRichTextEditor');
+}
+
 const change = (state: EditorState) => {
     // More info about EditorState object at
     // https://draftjs.org/docs/api-reference-editor-state
@@ -28,6 +32,7 @@ const Events = () => {
             label="Open the console to see the event callback as you type..."
             onSave={save}
             onChange={change}
+            onFocus={focus}
         />
     )
 }

--- a/src/MUIRichTextEditor.tsx
+++ b/src/MUIRichTextEditor.tsx
@@ -108,6 +108,7 @@ interface IMUIRichTextEditorProps extends WithStyles<typeof styles> {
     onSave?: (data: string) => void
     onChange?: (state: EditorState) => void
     onFocus?: () => void
+    onBlur?: () => void
 }
 
 type IMUIRichTextEditorState = {
@@ -335,6 +336,9 @@ const MUIRichTextEditor: RefForwardingComponent<any, IMUIRichTextEditorProps> = 
     }
 
     const handleBlur = () => {
+        if (props.onBlur) {
+            props.onBlur()
+        }
         setFocus(false)
         if (!state.anchorUrlPopover) {
             setState({

--- a/src/MUIRichTextEditor.tsx
+++ b/src/MUIRichTextEditor.tsx
@@ -107,6 +107,7 @@ interface IMUIRichTextEditorProps extends WithStyles<typeof styles> {
     maxLength?: number
     onSave?: (data: string) => void
     onChange?: (state: EditorState) => void
+    onFocus?: () => void
 }
 
 type IMUIRichTextEditorState = {
@@ -326,6 +327,9 @@ const MUIRichTextEditor: RefForwardingComponent<any, IMUIRichTextEditorProps> = 
     }
 
     const handleFocus = () => {
+        if (props.onFocus) {
+            props.onFocus()
+        }
         setFocus(true)
         setTimeout(() => (editorRef.current as any).focus(), 0)
     }


### PR DESCRIPTION
Hi,

Thank you for your work. I was wondering if it was possible to add 'onFocus' and 'onBlur' properties. In order to track focus on the Editor.

Thank you.