### PR TITLE
Remove compatible spacing for material-ui 3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mui-rte",
-  "version": "1.16.2",
+  "version": "1.16.3",
   "description": "Material-UI Rich Text Editor and Viewer",
   "keywords": [
     "material-ui",

--- a/src/MUIRichTextEditor.tsx
+++ b/src/MUIRichTextEditor.tsx
@@ -16,13 +16,13 @@ import Media from './components/Media'
 import Blockquote from './components/Blockquote'
 import CodeBlock from './components/CodeBlock'
 import UrlPopover, { TAlignment, TUrlData, TMediaType } from './components/UrlPopover'
-import { getSelectionInfo, getCompatibleSpacing, removeBlockFromMap, atomicBlockExists, isGt, clearInlineStyles } from './utils'
+import { getSelectionInfo, removeBlockFromMap, atomicBlockExists, isGt, clearInlineStyles } from './utils'
 
 const styles = ({ spacing, typography, palette }: Theme) => createStyles({
     root: {
     },
     container: {
-        margin: getCompatibleSpacing(spacing, 1, 0, 0, 0),
+        margin: spacing(1, 0, 0, 0),
         position: "relative",
         fontFamily: typography.body1.fontFamily,
         fontSize: typography.body1.fontSize,
@@ -36,10 +36,10 @@ const styles = ({ spacing, typography, palette }: Theme) => createStyles({
     editor: {
     },
     editorContainer: {
-        margin: getCompatibleSpacing(spacing, 1, 0, 0, 0),
+        margin: spacing(1, 0, 0, 0),
         cursor: "text",
         width: "100%",
-        padding: getCompatibleSpacing(spacing, 0, 0, 1, 0)
+        padding: spacing(0, 0, 1, 0)
     },
     editorReadOnly: {
         borderBottom: "none"
@@ -55,7 +55,7 @@ const styles = ({ spacing, typography, palette }: Theme) => createStyles({
         position: "absolute"
     },
     linkPopover: {
-        padding: getCompatibleSpacing(spacing, 2, 2, 2, 2)
+        padding: spacing(2, 2, 2, 2)
     },
     linkTextField: {
         width: "100%"

--- a/src/components/CodeBlock.tsx
+++ b/src/components/CodeBlock.tsx
@@ -1,11 +1,10 @@
 import * as React from 'react'
 import { createStyles, withStyles, WithStyles, Theme } from '@material-ui/core/styles'
-import { getCompatibleSpacing } from '../utils'
 
 const styles = ({ spacing, palette }: Theme) => createStyles({
     root: {
         backgroundColor: palette.grey[200],
-        padding: getCompatibleSpacing(spacing, 1, 2, 1, 2)
+        padding: spacing(1, 2, 1, 2)
     }
 })
 

--- a/src/components/UrlPopover.tsx
+++ b/src/components/UrlPopover.tsx
@@ -12,11 +12,10 @@ import DeleteIcon from '@material-ui/icons/DeleteOutline'
 import FormatAlignCenter from '@material-ui/icons/FormatAlignCenter'
 import FormatAlignLeft from '@material-ui/icons/FormatAlignLeft'
 import FormatAlignRight from '@material-ui/icons/FormatAlignRight'
-import { getCompatibleSpacing } from '../utils'
 
 const styles = ({ spacing }: Theme) => createStyles({
     linkPopover: {
-        padding: getCompatibleSpacing(spacing, 2, 2, 2, 2),
+        padding: spacing(2, 2, 2, 2),
         maxWidth: 250
     },
     linkTextField: {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -36,21 +36,6 @@ const getSelectionInfo = (editorState: EditorState): TSelectionInfo => {
 }
 
 /**
- * Spacing compatible for material-ui v3.2.x ~ v.4.x.x
- */
-const getCompatibleSpacing = (spacing: any, 
-    top: number, 
-    right: number, 
-    bottom: number, 
-    left: number) => {
-    if (typeof spacing === "function") {
-        return spacing(top, right, bottom, left)
-    }
-    const unit = (spacing as any).unit
-    return `${top * unit}px ${right * unit}px ${bottom * unit}px ${left * unit}px`
-}
-
-/**
  * Remove a block from the ContentState
  */
 const removeBlockFromMap = (editorState: EditorState, block: ContentBlock): ContentState => {
@@ -96,4 +81,4 @@ const clearInlineStyles = (editorState: EditorState): ContentState => {
     ), editorState.getCurrentContent())
 }
 
-export { getSelectionInfo, getCompatibleSpacing, removeBlockFromMap, atomicBlockExists, isGt, clearInlineStyles }
+export { getSelectionInfo, removeBlockFromMap, atomicBlockExists, isGt, clearInlineStyles }


### PR DESCRIPTION
Compatibility with `material-ui` v3 was dropped in previous versions of this package but legacy code for creating a `spacing` function was left. Now it is removed.