### PR TITLE
Add 'onFocus' and 'onBlur' event properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,7 +303,9 @@ Object.assign(defaultTheme, {
 |maxLength|`number`|optional|Sets the maximum characters count that can be input into the editor.|
 |autocomplete|`TAutocomplete`|optional|Sets autocomplete strategies to present suggestion lists as the user types into the editor.|
 |onSave|`(data:string) => void`|optional|Function triggered when the save button is pressed. The `data` is a stringified `Draft.Model.Encoding.RawDraftContentState` object.|
-|onChange|`(state: EditorState) => void`|optional|Function triggered on any change in the editor (key input, delete, etc.). The `state` is a `Draft.Model.ImmutableData.EditorState` object.|   
+|onChange|`(state: EditorState) => void`|optional|Function triggered on any change in the editor (key input, delete, etc.). The `state` is a `Draft.Model.ImmutableData.EditorState` object.|
+|onFocus|`() => void`|optional|Function triggered when when the editor acquires focus.|
+|onBlur|`() => void`|optional|Function triggered when when the editor loses focus.|
 
 <br />
 

--- a/examples/events/index.tsx
+++ b/examples/events/index.tsx
@@ -22,12 +22,22 @@ const change = (state: EditorState) => {
     }
 }
 
+const focus = () => {
+    console.log('Focus on MUIRichTextEditor');
+}
+
+const blur = () => {
+    console.log('Blur, focus lost on MUIRichTextEditor');
+}
+
 const Events = () => {
     return (
         <MUIRichTextEditor 
             label="Open the console to see the event callback as you type..."
             onSave={save}
             onChange={change}
+            onFocus={focus}
+            onBlur={blur}
         />
     )
 }

--- a/src/MUIRichTextEditor.tsx
+++ b/src/MUIRichTextEditor.tsx
@@ -87,6 +87,8 @@ export type TMUIRichTextEditorProps = {
     autocomplete?: TAutocomplete
     onSave?: (data: string) => void
     onChange?: (state: EditorState) => void
+    onFocus?: () => void
+    onBlur?: () => void
 }
 
 interface IMUIRichTextEditorProps extends TMUIRichTextEditorProps, WithStyles<typeof styles> {}
@@ -502,10 +504,17 @@ const MUIRichTextEditor: RefForwardingComponent<TMUIRichTextEditorRef, IMUIRichT
     const handleFocus = () => {
         setFocus(true)
         setTimeout(() => (editorRef.current as any).focus(), 0)
+        if (props.onFocus) {
+            props.onFocus()
+        }
     }
 
     const handleBlur = () => {
         setFocus(false)
+        if (props.onBlur) {
+            props.onBlur()
+        }
+
         if (!state.anchorUrlPopover) {
             setState({
                 ...state,


### PR DESCRIPTION
This pull request is basically a duplicate of #98.

I also wanted to use the `onFocus` and `onBlur` events so the mui-rte can be integrated properly with Material UI's TextField.

The other pull request was basically accepted, but not up to date with master. No changes have been made for a while, so I thought to make a new up to date pull request for it myself. I've applied the same changes, though to the most recent version.