### PR TITLE
Allow to cancel the popovers by clicking away

### DIFF
--- a/src/MUIRichTextEditor.tsx
+++ b/src/MUIRichTextEditor.tsx
@@ -689,6 +689,10 @@ const MUIRichTextEditor: RefForwardingComponent<TMUIRichTextEditorRef, IMUIRichT
         confirmLink(...args)
     }
 
+    const handleClosePrompt = () => {
+        setState({ ...state, anchorUrlPopover: undefined })
+    }
+
     const handleToolbarClick = (style: string, type: string, id: string, inlineMode?: boolean) => {
         if (type === "inline") {
             return toggleInlineStyle(style)
@@ -748,10 +752,7 @@ const MUIRichTextEditor: RefForwardingComponent<TMUIRichTextEditorRef, IMUIRichT
                 removeLink()
                 return
             }
-            setState({
-                ...state,
-                anchorUrlPopover: undefined
-            })
+            handleClosePrompt()
             return
         }
 
@@ -792,10 +793,7 @@ const MUIRichTextEditor: RefForwardingComponent<TMUIRichTextEditorRef, IMUIRichT
             if (urlKey) {
                 removeMedia()
             }
-            setState({
-                ...state,
-                anchorUrlPopover: undefined
-            })
+            handleClosePrompt()
             return
         }
 
@@ -1062,6 +1060,7 @@ const MUIRichTextEditor: RefForwardingComponent<TMUIRichTextEditorRef, IMUIRichT
                         data={state.urlData}
                         anchor={state.anchorUrlPopover}
                         onConfirm={handleConfirmPrompt}
+                        onCancel={handleClosePrompt}
                         isMedia={state.urlIsMedia}
                     />
                     : null}

--- a/src/components/UrlPopover.tsx
+++ b/src/components/UrlPopover.tsx
@@ -30,6 +30,7 @@ interface IUrlPopoverStateProps extends WithStyles<typeof styles> {
     data?: TUrlData
     isMedia?: boolean
     onConfirm: (isMedia?: boolean, ...args: any) => void
+    onCancel: () => void
 }
 
 const styles = ({ spacing }: Theme) => createStyles({
@@ -68,6 +69,7 @@ const UrlPopover: FunctionComponent<IUrlPopoverStateProps> = (props) => {
     return (
         <Popover
             open={props.anchor !== undefined}
+            onClose={props.onCancel}
             anchorEl={props.anchor}
             anchorOrigin={{
                 vertical: "bottom",


### PR DESCRIPTION
Currently the popovers can only be closed by either confirming or emptying the value. I find that I'm missing the (default) click away behaviour of the popovers, which acts as a cancel. Therefore I've added it. I think this improves the user experience of the popovers.