### PR TITLE
Add an example of Material UI TextField integration

### DIFF
--- a/examples/main.tsx
+++ b/examples/main.tsx
@@ -14,6 +14,7 @@ import ResetValue from './reset-value'
 import AtomicCustomBlock from './atomic-custom-block'
 import KeyBindings from './key-bindings'
 import MaxLength from './max-length'
+import MUITextFieldIntegration from './mui-textfield-integration'
 import Autocomplete from './autocomplete'
 import AutocompleteAtomic from './autocomplete-atomic'
 import AsyncImageUpload from './async-image-upload'
@@ -46,6 +47,7 @@ const App = () => {
             <button onClick={() => setSample(<ResetValue />)}>Reset value</button>
             <button onClick={() => setSample(<KeyBindings />)}>Key Bindings</button>
             <button onClick={() => setSample(<MaxLength />)}>Max length</button>
+            <button onClick={() => setSample(<MUITextFieldIntegration />)}>Material UI TextField Integration</button>
             <button onClick={() => setSample(<Autocomplete />)}>Autocomplete</button>
             <button onClick={() => setSample(<AutocompleteAtomic />)}>Autocomplete Atomic</button>
             <div style={{

--- a/examples/mui-textfield-integration/RichTextField.tsx
+++ b/examples/mui-textfield-integration/RichTextField.tsx
@@ -1,0 +1,89 @@
+import React, { Ref, useRef, useImperativeHandle, useEffect, useState } from 'react'
+import TextField, { TextFieldProps } from '@material-ui/core/TextField'
+import { InputBaseComponentProps } from '@material-ui/core/InputBase'
+import { EditorState } from 'draft-js'
+import MUIRichTextEditor from '../../'
+import { TMUIRichTextEditorRef } from '../../src/MUIRichTextEditor'
+
+export interface RichTextInputProps extends Omit<InputBaseComponentProps, 'value'> {
+    inputRef?: Ref<unknown>
+    doFocus?: boolean
+    onStateChange?: (state: EditorState) => void
+}
+
+export const RichTextInput = ({
+    inputRef,
+    doFocus,
+    onStateChange,
+    controls,
+    ...richTextProps
+}: RichTextInputProps) => {
+    const acquireFocus = doFocus ?? false
+
+    // Setup ref for the rich text editor
+    const richTextRef = useRef<TMUIRichTextEditorRef>(null)
+
+    // Attempts to focus the rich text editor reference
+    const focusRichText = () => richTextRef.current?.focus()
+
+    // Pass on the focus event of the input ref to the rich text ref
+    useImperativeHandle(inputRef, () => ({ focus: () => focusRichText }))
+
+    // If the `acquireFocus` is changed and its value is `true`, focus the editor
+    useEffect(() => {
+        if (acquireFocus) {
+            focusRichText()
+        }
+    }, [acquireFocus])
+
+    return (
+        <MUIRichTextEditor
+            {...richTextProps}
+            ref={richTextRef}
+            onChange={onStateChange}
+        />
+    )
+}
+
+export interface RichTextFieldProps extends Omit<TextFieldProps, 'value' | 'onChange'> {
+    defaultValue?: string
+    onChange?: (state: EditorState) => void
+}
+
+const RichTextField = ({
+    id,
+    placeholder,
+    defaultValue,
+    onChange,
+    InputLabelProps,
+    variant,
+    ...textFieldProps
+}: RichTextFieldProps) => {
+    // Manually handle the TextField's focused state based on the editor's focused state
+    const [isFocused, setIsFocused] = useState(false)
+
+    const inputProps: RichTextInputProps = {
+        id: id,
+        defaultValue: defaultValue,
+        label: placeholder,
+        inlineToolbar: true,
+        onStateChange: onChange,
+        doFocus: isFocused,
+        onFocus: () => setIsFocused(true),
+        onBlur: () => setIsFocused(false),
+    }
+
+    return (
+        <TextField
+            {...textFieldProps}
+            id={id}
+            variant={variant} // Required to compile due to TextFieldProps variant incompatibility
+            focused={isFocused}
+            onClick={() => setIsFocused(true)}
+            InputLabelProps={{ ...InputLabelProps, shrink: true }}
+            InputProps={{ inputComponent: RichTextInput, inputProps: inputProps }}
+        />
+    )
+}
+
+export default RichTextField

--- a/examples/mui-textfield-integration/index.tsx
+++ b/examples/mui-textfield-integration/index.tsx
@@ -1,0 +1,32 @@
+import React from 'react'
+import { makeStyles } from '@material-ui/core/styles'
+import RichTextField from './RichTextField'
+import { EditorState } from 'draft-js'
+
+const useStyles = makeStyles({
+    richTextField: {
+        '& #mui-rte-root': {
+            minHeight: 192,
+            padding: '0 16px',
+        },
+    },
+})
+
+const change = (state: EditorState) => {
+    console.log(state)
+}
+
+const MUITextFieldIntegration = () => {
+    const classes = useStyles()
+    return (
+        <RichTextField
+            variant="outlined"
+            label="TextField label"
+            helperText="Some TextField helper text"
+            placeholder="Type something here..."
+            onChange={change}
+            className={classes.richTextField} />
+    )
+}
+
+export default MUITextFieldIntegration


### PR DESCRIPTION
I've integrated mui-rte editor in a form I built. I wanted it to have the same style and behaviour as the other Material UI form elements. Preferably also with similar code usage.

Material UI describes [how 3rd party libraries can integrate](https://material-ui.com/components/text-fields/#integration-with-3rd-party-input-libraries) with its `TextField` component. Which is in itself composed using other input components default available in Material UI. I wrapped `MUIRichTextEditor` in a custom `RichTextField` component that is setup according to the Material UI `TextField` integration.

The `RichTextField` integrates nicely with the other elements in my form. The style and behaviour are the same and the code usage is very similar and consistent.

I wanted to share this setup so other people can possibly take advantage of this. Therefore I've added an example that uses the custom `RichTextField` component that integrates nicely with the `TextField` api.

<img width="819" alt="MUITextFieldIntegration" src="https://user-images.githubusercontent.com/32896803/83895503-0f5b7e80-a753-11ea-9188-09150716ef74.png">