### PR TITLE
Use Link component

### DIFF
--- a/examples/theme/index.tsx
+++ b/examples/theme/index.tsx
@@ -39,7 +39,8 @@ Object.assign(defaultTheme, {
                 top: "20px"
             },
             anchorLink: {
-                color: "#333333"
+                color: "#333333",
+                textDecoration: "underline"
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mui-rte",
-  "version": "1.22.1",
+  "version": "1.23.0",
   "description": "Material-UI Rich Text Editor and Viewer",
   "keywords": [
     "material-ui",

--- a/src/MUIRichTextEditor.tsx
+++ b/src/MUIRichTextEditor.tsx
@@ -159,8 +159,6 @@ const styles = ({ spacing, typography, palette }: Theme) => createStyles({
         width: "100%"
     },
     anchorLink: {
-        textDecoration: "underline",
-        color: "inherit"
     },
     toolbar: {
     },

--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -1,5 +1,6 @@
 import React, { FunctionComponent } from 'react'
 import { ContentState } from 'draft-js'
+import MuiLink from '@material-ui/core/Link'
 
 type TLinkProps = {
     children?: React.ReactNode
@@ -10,13 +11,13 @@ type TLinkProps = {
 const Link: FunctionComponent<TLinkProps> = (props) => {
     const { url, className } = props.contentState.getEntity(props.entityKey).getData()
     return (
-        <a 
+        <MuiLink 
             href={url} 
             className={`${className} editor-anchor`}
             target="_blank"
         >
             {props.children}
-        </a>
+        </MuiLink>
     )
 }
 


### PR DESCRIPTION
- Use `material-ui`'s `Link` component for rendering links in the editor. (#147)