### PR TITLE
Fix onChange property trigger

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mui-rte",
-  "version": "1.23.0",
+  "version": "1.23.1",
   "description": "Material-UI Rich Text Editor and Viewer",
   "keywords": [
     "material-ui",

--- a/src/MUIRichTextEditor.tsx
+++ b/src/MUIRichTextEditor.tsx
@@ -320,6 +320,9 @@ const MUIRichTextEditor: RefForwardingComponent<TMUIRichTextEditorRef, IMUIRichT
     }, [props.value, props.defaultValue])
 
     useEffect(() => {
+        if (props.onChange) {
+            props.onChange(editorState)
+        }
         editorStateRef.current = editorState
     }, [editorState])
 
@@ -483,9 +486,6 @@ const MUIRichTextEditor: RefForwardingComponent<TMUIRichTextEditorRef, IMUIRichT
 
     const handleChange = (state: EditorState) => {
         setEditorState(state)
-        if (props.onChange) {
-            props.onChange(state)
-        }
     }
 
     const handleBeforeInput = (chars: string): DraftHandleValue => {


### PR DESCRIPTION
- Trigger `onChange` property when setting `MUIRichTextEditor`'s `editorState` (#146)