### PR TITLE
Remove auto focus on load

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mui-rte",
-  "version": "1.25.0",
+  "version": "1.26.0",
   "description": "Material-UI Rich Text Editor and Viewer",
   "keywords": [
     "material-ui",

--- a/src/MUIRichTextEditor.tsx
+++ b/src/MUIRichTextEditor.tsx
@@ -1,5 +1,5 @@
 import React, { FunctionComponent, useEffect, useState, useRef, 
-    forwardRef, useImperativeHandle, RefForwardingComponent, SyntheticEvent } from 'react'
+    forwardRef, useImperativeHandle, RefForwardingComponent } from 'react'
 import Immutable from 'immutable'
 import classNames from 'classnames'
 import { createStyles, withStyles, WithStyles, Theme } from '@material-ui/core/styles'
@@ -260,6 +260,7 @@ const MUIRichTextEditor: RefForwardingComponent<TMUIRichTextEditorRef, IMUIRichT
     const isFirstFocus = useRef(true)
     const customBlockMapRef = useRef<DraftBlockRenderMap | undefined>(undefined)
     const customStyleMapRef = useRef<DraftStyleMap | undefined>(undefined)
+    const isFocusedWithMouse = useRef(false)
     const selectionRef = useRef<TStateOffset>({
         start: 0,
         end: 0
@@ -479,16 +480,10 @@ const MUIRichTextEditor: RefForwardingComponent<TMUIRichTextEditorRef, IMUIRichT
         return isMaxLengthHandled(editorState, 1)
     }
 
-    const isSyntheticEventTriggeredByTab = (event: SyntheticEvent): boolean => {
-        if (!event.hasOwnProperty("relatedTarget") || (event as any).relatedTarget == null) {
-            return false
-        }
-        return true
-    }
-
-    const handleEditorFocus = (event: SyntheticEvent) => {
+    const handleEditorFocus = () => {
         handleFocus()
-        if (!isSyntheticEventTriggeredByTab(event)) {
+        if (isFocusedWithMouse.current === true) {
+            isFocusedWithMouse.current = false
             return
         }
         const nextEditorState = EditorState.forceSelection(editorState, editorState.getSelection())
@@ -517,6 +512,7 @@ const MUIRichTextEditor: RefForwardingComponent<TMUIRichTextEditorRef, IMUIRichT
     }
 
     const handleBlur = () => {
+        isFocusedWithMouse.current = false
         setFocus(false)
         if (props.onBlur) {
             props.onBlur()
@@ -528,6 +524,10 @@ const MUIRichTextEditor: RefForwardingComponent<TMUIRichTextEditorRef, IMUIRichT
                 toolbarPosition: undefined
             })
         }
+    }
+
+    const handleMouseDown = () => {
+        isFocusedWithMouse.current = true
     }
 
     const handleClearFormat = () => {
@@ -1107,7 +1107,7 @@ const MUIRichTextEditor: RefForwardingComponent<TMUIRichTextEditorRef, IMUIRichT
                     <div id={`${editorId}-editor-container`} className={classNames(className, classes.editorContainer, {
                         [classes.editorReadOnly]: !editable,
                         [classes.error]: props.error
-                    })} onBlur={handleBlur}>
+                    })} onMouseDown={handleMouseDown} onBlur={handleBlur}>
                         <Editor
                             blockRenderMap={getBlockMap()}
                             blockRendererFn={blockRenderer}

--- a/src/MUIRichTextEditor.tsx
+++ b/src/MUIRichTextEditor.tsx
@@ -979,6 +979,15 @@ const MUIRichTextEditor: RefForwardingComponent<TMUIRichTextEditorRef, IMUIRichT
         return null
     }
 
+    const styleRenderer = (style: any, _block: ContentBlock): React.CSSProperties => {
+        const customStyleMap = getStyleMap()
+        const styleNames = style.toJS()
+        return styleNames.reduce((styles: any, styleName: string) => {
+            styles = customStyleMap[styleName]
+            return styles
+        }, {})
+    }
+
     const insertAtomicBlock = (editorState: EditorState, type: string, data: any, options?: any) => {
         const contentState = editorState.getCurrentContent()
         const contentStateWithEntity = contentState.createEntity(type, 'IMMUTABLE', data)
@@ -1125,9 +1134,9 @@ const MUIRichTextEditor: RefForwardingComponent<TMUIRichTextEditorRef, IMUIRichT
                         [classes.error]: props.error
                     })} onBlur={handleBlur}>
                         <Editor
-                            customStyleMap={customRenderers.style}
                             blockRenderMap={getBlockMap()}
                             blockRendererFn={blockRenderer}
+                            customStyleFn={styleRenderer}
                             editorState={editorState}
                             onChange={handleChange}
                             onFocus={handleEditorFocus}

--- a/src/MUIRichTextEditor.tsx
+++ b/src/MUIRichTextEditor.tsx
@@ -263,6 +263,7 @@ const MUIRichTextEditor: RefForwardingComponent<TMUIRichTextEditorRef, IMUIRichT
     const autocompleteLimit = props.autocomplete ? props.autocomplete.suggestLimit || 5 : 5
     const isFirstFocus = useRef(true)
     const customBlockMapRef = useRef<DraftBlockRenderMap | undefined>(undefined)
+    const customStyleMapRef = useRef<DraftStyleMap | undefined>(undefined)
     const selectionRef = useRef<TStateOffset>({
         start: 0,
         end: 0
@@ -904,6 +905,24 @@ const MUIRichTextEditor: RefForwardingComponent<TMUIRichTextEditorRef, IMUIRichT
         handlePromptForMedia(false, newEditorState)
     }
 
+    const getStyleMap = (): DraftStyleMap => {
+        if (customStyleMapRef.current === undefined) {
+            setupStyleMap()
+        }
+        return customStyleMapRef.current!
+    }
+
+    const setupStyleMap = () => {
+        const customStyleMap = JSON.parse(JSON.stringify(styleRenderMap))
+        if (props.customControls) {
+            props.customControls.forEach(control => {
+                if (control.type === "inline" && control.inlineStyle) {
+                    customStyleMap[control.name.toUpperCase()] = control.inlineStyle
+                }
+            })
+        }
+        customStyleMapRef.current = customStyleMap
+    }
 
     const getBlockMap = (): DraftBlockRenderMap => {
         if (customBlockMapRef.current === undefined) {

--- a/src/MUIRichTextEditor.tsx
+++ b/src/MUIRichTextEditor.tsx
@@ -1087,6 +1087,7 @@ const MUIRichTextEditor: RefForwardingComponent<TMUIRichTextEditorRef, IMUIRichT
                             controls={inlineToolbarControls}
                             customControls={customControls}
                             inlineMode={true}
+                            isActive={true}
                         />
                     </Paper>
                     : null}
@@ -1100,6 +1101,7 @@ const MUIRichTextEditor: RefForwardingComponent<TMUIRichTextEditorRef, IMUIRichT
                         className={classes.toolbar}
                         disabled={!editable}
                         size={props.toolbarButtonSize}
+                        isActive={focus}
                     />
                     : null}
                 {placeholder}

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -69,6 +69,7 @@ type TToolbarProps = {
     className?: string
     disabled?: boolean
     size?: TToolbarButtonSize
+    isActive: boolean
 }
 
 const STYLE_TYPES: TStyleType[] = [

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -234,7 +234,10 @@ const Toolbar: FunctionComponent<TToolbarProps> = (props) => {
                 }
                 let active = false
                 const action = props.onClick
-                if (style.type === "inline") {
+                if (!props.isActive) {
+                    active = false
+                }
+                else if (style.type === "inline") {
                     active = editorState.getCurrentInlineStyle().has(style.style)
                 }
                 else if (style.type === "block") {

--- a/test/Toolbar.test.tsx
+++ b/test/Toolbar.test.tsx
@@ -18,6 +18,7 @@ describe('<EditorControls />', () => {
                 id="mui-rte"
                 editorState={editorState}
                 onClick={() => {}}
+                isActive={true}
             />
         )
         const result = wrapper.find(EditorButton)
@@ -41,6 +42,7 @@ describe('<EditorControls />', () => {
                 editorState={editorState}
                 controls={controls}
                 onClick={() => {}}
+                isActive={true}
             />
         )
         const result = wrapper.find(EditorButton).map(item => {
@@ -56,6 +58,7 @@ describe('<EditorControls />', () => {
                 editorState={editorState}
                 controls={[]}
                 onClick={() => {}}
+                isActive={true}
             />
         )
         const result = wrapper.find(EditorButton)


### PR DESCRIPTION
- Removes automatic focus on load when the editor has contents. (#158)
- Sets the focus cursor position to a mouse event instead of tab only. (#184 )
- Sets the toolbar buttons active value to `false` when the editor is not focused.
- Bumps the package version.