### PR TITLE
Update exports

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,1 +1,1 @@
-export {default} from './dist/MUIRichTextEditor'
+module.exports = require('./dist/MUIRichTextEditor')


### PR DESCRIPTION
In NextJS12, the present configuration produces an error. 

This can be rectified by using `module.exports = require('./dist/MUIRichTextEditor')`
