### PR TITLE
Make autocompleteMinSearchCharCount prop

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -135,6 +135,7 @@ export declare type TMUIRichTextEditorProps = {
     keyCommands?: TKeyCommand[];
     maxLength?: number;
     autocomplete?: TAutocomplete;
+    autocompleteMinSearchCharCount?: number;
     onSave?: (data: string) => void;
     onChange?: (state: EditorState) => void;
     onFocus?: () => void;

--- a/index.d.ts
+++ b/index.d.ts
@@ -88,6 +88,7 @@ export declare type TAutocompleteStrategy = {
 };
 export declare type TAutocomplete = {
     strategies: TAutocompleteStrategy[];
+    minSearchCharCount?: number;
     suggestLimit?: number;
 };
 export declare type TAsyncAtomicBlockResponse = {
@@ -135,7 +136,6 @@ export declare type TMUIRichTextEditorProps = {
     keyCommands?: TKeyCommand[];
     maxLength?: number;
     autocomplete?: TAutocomplete;
-    autocompleteMinSearchCharCount?: number;
     onSave?: (data: string) => void;
     onChange?: (state: EditorState) => void;
     onFocus?: () => void;

--- a/src/MUIRichTextEditor.tsx
+++ b/src/MUIRichTextEditor.tsx
@@ -271,7 +271,7 @@ const MUIRichTextEditor: ForwardRefRenderFunction<TMUIRichTextEditorRef, IMUIRic
     const autocompleteSelectionStateRef = useRef<SelectionState | undefined>(undefined)
     const autocompletePositionRef = useRef<TPosition | undefined>(undefined)
     const autocompleteLimit = props.autocomplete ? props.autocomplete.suggestLimit || 5 : 5
-    const autocompleteMinSearchCharCount = props?.autocomplete?.minSearchCharCount || 2;
+    const autocompleteMinSearchCharCount =  props?.autocomplete?.minSearchCharCount ?? 2;
     const isFirstFocus = useRef(true)
     const customBlockMapRef = useRef<DraftBlockRenderMap | undefined>(undefined)
     const customStyleMapRef = useRef<DraftStyleMap | undefined>(undefined)

--- a/src/MUIRichTextEditor.tsx
+++ b/src/MUIRichTextEditor.tsx
@@ -88,6 +88,7 @@ export type TMUIRichTextEditorProps = {
     keyCommands?: TKeyCommand[]
     maxLength?: number
     autocomplete?: TAutocomplete
+    autocompleteMinSearchCharCount?: number;
     onSave?: (data: string) => void
     onChange?: (state: EditorState) => void
     onFocus?: () => void
@@ -201,7 +202,6 @@ const styleRenderMap: DraftStyleMap = {
 }
 
 const { hasCommandModifier } = KeyBindingUtil
-const autocompleteMinSearchCharCount = 2
 const lineHeight = 26
 const defaultInlineToolbarControls = ["bold", "italic", "underline", "clear"]
 
@@ -250,7 +250,12 @@ const useEditorState = (props: IMUIRichTextEditorProps) => {
 }
 
 const MUIRichTextEditor: ForwardRefRenderFunction<TMUIRichTextEditorRef, IMUIRichTextEditorProps> = (props, ref) => {
-    const { classes, controls, customControls } = props
+    const {
+      classes,
+      controls,
+      customControls,
+      autocompleteMinSearchCharCount = 2
+    } = props;
 
     const [state, setState] = useState<TMUIRichTextEditorState>({})
     const [focus, setFocus] = useState(false)

--- a/src/MUIRichTextEditor.tsx
+++ b/src/MUIRichTextEditor.tsx
@@ -37,6 +37,7 @@ export type TAutocompleteStrategy = {
 export type TAutocomplete = {
     strategies: TAutocompleteStrategy[]
     suggestLimit?: number
+    minSearchCharCount?: number;
 }
 
 export type TAsyncAtomicBlockResponse = {
@@ -88,7 +89,6 @@ export type TMUIRichTextEditorProps = {
     keyCommands?: TKeyCommand[]
     maxLength?: number
     autocomplete?: TAutocomplete
-    autocompleteMinSearchCharCount?: number;
     onSave?: (data: string) => void
     onChange?: (state: EditorState) => void
     onFocus?: () => void
@@ -254,7 +254,6 @@ const MUIRichTextEditor: ForwardRefRenderFunction<TMUIRichTextEditorRef, IMUIRic
       classes,
       controls,
       customControls,
-      autocompleteMinSearchCharCount = 2
     } = props;
 
     const [state, setState] = useState<TMUIRichTextEditorState>({})
@@ -272,6 +271,7 @@ const MUIRichTextEditor: ForwardRefRenderFunction<TMUIRichTextEditorRef, IMUIRic
     const autocompleteSelectionStateRef = useRef<SelectionState | undefined>(undefined)
     const autocompletePositionRef = useRef<TPosition | undefined>(undefined)
     const autocompleteLimit = props.autocomplete ? props.autocomplete.suggestLimit || 5 : 5
+    const autocompleteMinSearchCharCount = props?.autocomplete?.minSearchCharCount || 2;
     const isFirstFocus = useRef(true)
     const customBlockMapRef = useRef<DraftBlockRenderMap | undefined>(undefined)
     const customStyleMapRef = useRef<DraftStyleMap | undefined>(undefined)


### PR DESCRIPTION
This simple change should allow us to specify a value for `autocompleteMinSearchCharCount` while maintaining the current behavior for existing use.