### PR TITLE
fix: export error "export {default} from './dist/MUIRichTextEditor'"

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,33 @@
+# This workflow will run tests using node and then publish a package to GitHub Packages when a release is created
+# For more information see: https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages
+
+name: Node.js Package
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+      - run: npm ci
+      - run: npm test
+
+  publish-npm:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          registry-url: https://registry.npmjs.org/
+      - run: npm ci
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.npm_token}}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
-# mui-rte  
+# mui-rte-fixed
 
-The Material-UI Rich Text Editor and Viewer
+The Material-UI Rich Text Editor and Viewer Fixed Version
+
+#### Fixs the annoying error
+```ts
+export {default} from './dist/MUIRichTextEditor'
+```
 
 <img src="https://raw.githubusercontent.com/niuware/niuware.github.io/master/public/assets/mui-rte/editor-1-9-0.png" width="600" />
 

--- a/index.js
+++ b/index.js
@@ -1,1 +1,1 @@
-export {default} from './dist/MUIRichTextEditor'
+const MUIRichTextEditor = require('./dist/MUIRichTextEditor'); module.exports = MUIRichTextEditor;


### PR DESCRIPTION
Changing `export {default} from './dist/MUIRichTextEditor'` to `const MUIRichTextEditor = require('./dist/MUIRichTextEditor'); module.exports = MUIRichTextEditor;`